### PR TITLE
Fix xdoc overrides not being taken into account

### DIFF
--- a/distribution/hsqldb-database/pom.xml
+++ b/distribution/hsqldb-database/pom.xml
@@ -32,6 +32,13 @@
     </dependency>
     <dependency>
       <groupId>${project.groupId}</groupId>
+      <artifactId>phenotips-niaid-ui</artifactId>
+      <version>${project.version}</version>
+      <type>xar</type>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>${project.groupId}</groupId>
       <artifactId>patient-data-sharing-push-ui</artifactId>
       <version>${phenotips.version}</version>
       <type>xar</type>
@@ -41,13 +48,6 @@
       <groupId>${project.groupId}</groupId>
       <artifactId>patient-data-sharing-receiver-ui</artifactId>
       <version>${phenotips.version}</version>
-      <type>xar</type>
-      <scope>provided</scope>
-    </dependency>
-    <dependency>
-      <groupId>${project.groupId}</groupId>
-      <artifactId>phenotips-niaid-ui</artifactId>
-      <version>${project.version}</version>
       <type>xar</type>
       <scope>provided</scope>
     </dependency>

--- a/distribution/ui/pom.xml
+++ b/distribution/ui/pom.xml
@@ -25,12 +25,6 @@
   <dependencies>
     <dependency>
       <groupId>${project.groupId}</groupId>
-      <artifactId>phenotips-ui</artifactId>
-      <version>${phenotips.version}</version>
-      <type>xar</type>
-    </dependency>
-    <dependency>
-      <groupId>${project.groupId}</groupId>
       <artifactId>patient-data-encrypted-ui</artifactId>
       <version>${project.version}</version>
       <type>xar</type>
@@ -63,6 +57,31 @@
       <groupId>${project.groupId}</groupId>
       <artifactId>phenotype-onset-exact-ui</artifactId>
       <version>${project.version}</version>
+      <type>xar</type>
+    </dependency>
+    <!-- Place upstream dependencies that contain overridden files here, so that they are indeed overridden by our modules -->
+    <dependency>
+      <groupId>${project.groupId}</groupId>
+      <artifactId>family-studies-ui</artifactId>
+      <version>${phenotips.version}</version>
+      <type>xar</type>
+    </dependency>
+    <dependency>
+      <groupId>${project.groupId}</groupId>
+      <artifactId>phenotips-pedigree-ui</artifactId>
+      <version>${phenotips.version}</version>
+      <type>xar</type>
+    </dependency>
+    <dependency>
+      <groupId>${project.groupId}</groupId>
+      <artifactId>patient-data-ui</artifactId>
+      <version>${phenotips.version}</version>
+      <type>xar</type>
+    </dependency>
+    <dependency>
+      <groupId>${project.groupId}</groupId>
+      <artifactId>phenotips-ui</artifactId>
+      <version>${phenotips.version}</version>
       <type>xar</type>
     </dependency>
   </dependencies>

--- a/encrypted-pii/ui/pom.xml
+++ b/encrypted-pii/ui/pom.xml
@@ -29,6 +29,13 @@
     </dependency>
     <dependency>
       <groupId>${project.groupId}</groupId>
+      <artifactId>phenotips-pedigree-ui</artifactId>
+      <version>${phenotips.version}</version>
+      <type>xar</type>
+      <scope>runtime</scope>
+    </dependency>
+    <dependency>
+      <groupId>${project.groupId}</groupId>
       <artifactId>patient-data-encrypted-backend</artifactId>
       <version>${project.version}</version>
       <scope>runtime</scope>

--- a/family-dashboard/ui/pom.xml
+++ b/family-dashboard/ui/pom.xml
@@ -22,7 +22,7 @@
   <dependencies>
     <dependency>
       <groupId>${project.groupId}</groupId>
-      <artifactId>patient-data-ui</artifactId>
+      <artifactId>family-studies-ui</artifactId>
       <version>${phenotips.version}</version>
       <type>xar</type>
       <scope>runtime</scope>

--- a/family-data-table/ui/pom.xml
+++ b/family-data-table/ui/pom.xml
@@ -27,7 +27,7 @@
   <dependencies>
     <dependency>
       <groupId>${project.groupId}</groupId>
-      <artifactId>patient-data-ui</artifactId>
+      <artifactId>family-studies-ui</artifactId>
       <version>${phenotips.version}</version>
       <type>xar</type>
     </dependency>

--- a/family-groups/ui/pom.xml
+++ b/family-groups/ui/pom.xml
@@ -22,13 +22,6 @@
   <dependencies>
     <dependency>
       <groupId>${project.groupId}</groupId>
-      <artifactId>patient-data-ui</artifactId>
-      <version>${phenotips.version}</version>
-      <type>xar</type>
-      <scope>runtime</scope>
-    </dependency>
-    <dependency>
-      <groupId>${project.groupId}</groupId>
       <artifactId>family-groups-api</artifactId>
       <version>${project.version}</version>
       <scope>runtime</scope>


### PR DESCRIPTION
Dependencies are imported in reverse order, so the topmost ones will be the ones that have priority; thus, move the upstream dependencies at the bottom